### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R:
     person(given = "Joe",
            family = "Thorley",
            role = c("aut", "cre"),
-           email = "joe@poissonconsulting.ca")
+           email = "joe@poissonconsulting.ca",
+           comment = c(ORCID = "0000-0002-7683-4592"))
 Description: Facilitates analyses using 'Template Model Builder'.
 License: MIT + file LICENSE
 URL: https://github.com/poissonconsulting/tmbr


### PR DESCRIPTION
Add Joe Thorley's ORCID (0000-0002-7683-4592).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)