### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/analyse.R
+++ b/R/analyse.R
@@ -10,7 +10,8 @@ list_by_name <- function(x) {
 
 add_report <- function(x) {
   x %<>% str_replace_all("\\sREPORT[(][^)]+[)];", "\n")
-  x %<>% str_replace_all("\\sADREPORT[(]([^)]+)[)]", "REPORT(\\1);\nADREPORT(\\1)")
+  x %<>%
+    str_replace_all("\\sADREPORT[(]([^)]+)[)]", "REPORT(\\1);\nADREPORT(\\1)")
   x
 }
 
@@ -28,7 +29,9 @@ load_dynlib <- function(model, tempfile) {
 }
 
 unload_dynlibs <- function(tempfiles) {
-  for (tempfile in tempfiles) try(dyn.unload(TMB::dynlib(tempfile)), silent = TRUE)
+  for (tempfile in tempfiles) {
+    try(dyn.unload(TMB::dynlib(tempfile)), silent = TRUE)
+  }
 }
 
 # Constructs a list identifying which parameters to fix (based on missing values in inits).
@@ -109,9 +112,16 @@ tmb_analysis <- function(data, model, tempfile, glance, quiet) {
   timer$start()
 
   obj <- list(model = model, data = data)
-  class(obj) <- c("mb_null_analysis", "tmb_ml_analysis", "tmb_analysis", "mb_analysis")
+  class(obj) <- c(
+    "mb_null_analysis",
+    "tmb_ml_analysis",
+    "tmb_analysis",
+    "mb_analysis"
+  )
 
-  if (glance) on.exit(print(glance(obj)))
+  if (glance) {
+    on.exit(print(glance(obj)))
+  }
 
   data %<>% modify_data(model = model)
 
@@ -119,15 +129,19 @@ tmb_analysis <- function(data, model, tempfile, glance, quiet) {
 
   map <- map(inits)
 
-  inits %<>% llply(function(x) {
-    x[is.na(x)] <- 0
-    x
-  })
+  inits %<>%
+    llply(function(x) {
+      x[is.na(x)] <- 0
+      x
+    })
 
   ad_fun <- TMB::MakeADFun(
-    data = data, inits, map = map,
+    data = data,
+    inits,
+    map = map,
     random = names(model$random_effects),
-    DLL = basename(tempfile), silent = quiet
+    DLL = basename(tempfile),
+    silent = quiet
   )
 
   opt <- try(do.call("optim", ad_fun))
@@ -160,13 +174,14 @@ tmb_analysis <- function(data, model, tempfile, glance, quiet) {
 
   mcmcr <- as.mcmcr(estimate)
 
-  obj %<>% c(
-    inits = list(inits),
-    logLik = logLik,
-    mcmcr = list(mcmcr),
-    sd = list(sd),
-    opt = list(opt)
-  )
+  obj %<>%
+    c(
+      inits = list(inits),
+      logLik = logLik,
+      mcmcr = list(mcmcr),
+      sd = list(sd),
+      opt = list(opt)
+    )
 
   class(obj) <- c("tmb_ml_analysis", "tmb_analysis", "mb_analysis")
 
@@ -180,16 +195,32 @@ analyse_tmb_data <- function(data, model, tempfile, glance, quiet) {
   load_dynlib(model, tempfile)
 
   if (is.data.frame(data)) {
-    return(tmb_analysis(data = data, model = model, tempfile = tempfile, glance = glance, quiet = quiet))
+    return(tmb_analysis(
+      data = data,
+      model = model,
+      tempfile = tempfile,
+      glance = glance,
+      quiet = quiet
+    ))
   }
 
-  plyr::llply(data, tmb_analysis, model = model, tempfile = tempfile, glance = glance, quiet = quiet)
+  plyr::llply(
+    data,
+    tmb_analysis,
+    model = model,
+    tempfile = tempfile,
+    glance = glance,
+    quiet = quiet
+  )
 }
 
 analyse_tmb_data_chunk <- function(data, model, quiet) {
   analyse_tmb_data(
-    data = data$data, model = model, tempfile = data$tempfile,
-    quiet = quiet, glance = FALSE
+    data = data$data,
+    model = model,
+    tempfile = data$tempfile,
+    quiet = quiet,
+    glance = FALSE
   )
 }
 
@@ -206,10 +237,13 @@ analyse_tmb_data_parallel <- function(data, model, quiet) {
 
   on.exit(unload_dynlibs(tempfiles))
 
-  data %<>% llply(
-    .fun = analyse_tmb_data_chunk, .parallel = TRUE,
-    model = model, quiet = quiet
-  )
+  data %<>%
+    llply(
+      .fun = analyse_tmb_data_chunk,
+      .parallel = TRUE,
+      model = model,
+      quiet = quiet
+    )
 
   data %<>% unlist(recursive = FALSE)
 
@@ -217,17 +251,22 @@ analyse_tmb_data_parallel <- function(data, model, quiet) {
 }
 
 #' @export
-analyse.tmb_model <- function(x, data,
-                              nchains = getOption("mb.nchains", 3L),
-                              niters = getOption("mb.niters", 1000L),
-                              nthin = getOption("mb.thin", NULL),
-                              parallel = getOption("mb.parallel", FALSE),
-                              quiet = getOption("mb.quiet", TRUE),
-                              glance = getOption("mb.glance", TRUE),
-                              beep = getOption("mb.beep", TRUE),
-                              ...) {
+analyse.tmb_model <- function(
+  x,
+  data,
+  nchains = getOption("mb.nchains", 3L),
+  niters = getOption("mb.niters", 1000L),
+  nthin = getOption("mb.thin", NULL),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   if (is.data.frame(data)) {
     check_data(data)
@@ -247,8 +286,11 @@ analyse.tmb_model <- function(x, data,
     tempfile <- tempfile()
     on.exit(unload_dynlibs(tempfile))
     return(analyse_tmb_data(
-      data = data, model = x, tempfile = tempfile,
-      quiet = quiet, glance = glance
+      data = data,
+      model = x,
+      tempfile = tempfile,
+      quiet = quiet,
+      glance = glance
     ))
   }
 

--- a/R/check.R
+++ b/R/check.R
@@ -17,7 +17,10 @@ check_model_pars.tmb_code <- function(x, fixed, random, derived, drops) {
     error("derived parameters missing from derived code parameters")
   }
 
-  if (length(drops) && !all(unlist(drops) %in% pars(x, param_type = "primary", scalar = TRUE))) {
+  if (
+    length(drops) &&
+      !all(unlist(drops) %in% pars(x, param_type = "primary", scalar = TRUE))
+  ) {
     error("drops parameters missing from primary scalar code pars")
   }
 

--- a/R/confint.R
+++ b/R/confint.R
@@ -17,9 +17,12 @@ adfun_confint <- function(terms, object, tempfile, level, ...) {
   load_dynlib(model, tempfile)
 
   ad_fun <- TMB::MakeADFun(
-    data = data, inits, map = map,
+    data = data,
+    inits,
+    map = map,
     random = names(model$random_effects),
-    DLL = basename(tempfile), silent = TRUE
+    DLL = basename(tempfile),
+    silent = TRUE
   )
 
   opt <- try(do.call("optim", ad_fun))
@@ -31,8 +34,11 @@ adfun_confint <- function(terms, object, tempfile, level, ...) {
 
 adfun_confint_chunk <- function(terms, object, level, ...) {
   confint <- adfun_confint(
-    terms = terms$terms, object = object, tempfile = terms$tempfile,
-    level = level, ...
+    terms = terms$terms,
+    object = object,
+    tempfile = terms$tempfile,
+    level = level,
+    ...
   )
 }
 
@@ -45,14 +51,19 @@ adfun_confint_parallel <- function(terms, object, level, ...) {
 
   tempfiles <- replicate(length(terms), tempfile())
 
-  terms %<>% purrr::map2(tempfiles, function(x, y) list(terms = x, tempfile = y))
+  terms %<>%
+    purrr::map2(tempfiles, function(x, y) list(terms = x, tempfile = y))
 
   on.exit(unload_dynlibs(tempfiles))
 
-  terms %<>% llply(
-    .fun = adfun_confint_chunk, .parallel = TRUE,
-    object = object, level = level, ...
-  )
+  terms %<>%
+    llply(
+      .fun = adfun_confint_chunk,
+      .parallel = TRUE,
+      object = object,
+      level = level,
+      ...
+    )
 
   terms %<>% dplyr::bind_rows()
   terms$term %<>% as_term()
@@ -70,25 +81,38 @@ adfun_confint_parallel <- function(terms, object, level, ...) {
 #' @param ... Addtional arguments passed to TMB::tmbprofile
 #' @export
 # need to parallelise and deal with terms
-confint.tmb_ml_analysis <- function(object, parm = terms(object),
-                                    level = getOption("mb.conf_level", 0.95),
-                                    parallel = getOption("mb.parallel", FALSE),
-                                    beep = getOption("mb.beep", FALSE),
-                                    ...) {
+confint.tmb_ml_analysis <- function(
+  object,
+  parm = terms(object),
+  level = getOption("mb.conf_level", 0.95),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.beep", FALSE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
   beep <- FALSE
 
   chk_scalar(level)
   chk_vector(level, c(0.5, 0.99))
   chk_flag(parallel)
 
-  if (!all(parm %in% terms(object, "all"))) error("not all terms recognised")
+  if (!all(parm %in% terms(object, "all"))) {
+    error("not all terms recognised")
+  }
 
   if (!parallel) {
     tempfile <- tempfile()
     on.exit(unload_dynlibs(tempfile))
-    return(adfun_confint(terms = parm, object = object, tempfile = tempfile, level = level, ...))
+    return(adfun_confint(
+      terms = parm,
+      object = object,
+      tempfile = tempfile,
+      level = level,
+      ...
+    ))
   }
   adfun_confint_parallel(terms = parm, object = object, level = level, ...)
 }

--- a/R/drop-parameters.R
+++ b/R/drop-parameters.R
@@ -13,10 +13,11 @@ drop_pars.tmb_code <- function(x, pars = character(0), ...) {
     if (!str_detect(template, str_c("PARAMETER[(]", parameter, "[)]"))) {
       error("fixed scalar parameter '", parameter, "' not found in model code")
     }
-    template %<>% str_replace(
-      str_c("PARAMETER[(]", parameter, "[)]"),
-      str_c("Type ", parameter, " = 0.0")
-    )
+    template %<>%
+      str_replace(
+        str_c("PARAMETER[(]", parameter, "[)]"),
+        str_c("Type ", parameter, " = 0.0")
+      )
   }
 
   x$template <- template

--- a/R/inits.R
+++ b/R/inits.R
@@ -19,7 +19,9 @@ check_dims_inits <- function(x, y) {
   x <- x[names(x) %in% names(y)]
   y <- y[names(x)]
   if (!identical(x, y)) {
-    error("dimensions of user-provided random inits must match those of random effects")
+    error(
+      "dimensions of user-provided random inits must match those of random effects"
+    )
   }
   x
 }

--- a/R/pars.R
+++ b/R/pars.R
@@ -10,11 +10,15 @@ pars.tmb_code <- function(x, param_type = "all", scalar = NA, ...) {
   chk_unused(...)
 
   if (param_type %in% c("fixed", "random")) {
-    error("parameters.tmb_code is not currently able to separate 'fixed' or 'random' parameter types - set param_type = 'primary' instead")
+    error(
+      "parameters.tmb_code is not currently able to separate 'fixed' or 'random' parameter types - set param_type = 'primary' instead"
+    )
   }
 
   if (param_type == "derived" && !is.na(scalar)) {
-    error("parameters.tmb is not currently able to identify scalar 'derived' parameter types - set scalar = NA instead")
+    error(
+      "parameters.tmb is not currently able to identify scalar 'derived' parameter types - set scalar = NA instead"
+    )
   }
 
   if (param_type == "all") {
@@ -32,13 +36,22 @@ pars.tmb_code <- function(x, param_type = "all", scalar = NA, ...) {
 
   if (param_type == "primary") {
     if (is.na(scalar)) {
-      x %<>% str_extract_all("\\s(PARAMETER(|_VECTOR|_MATRIX|_ARRAY))[(]\\w+[)]", simplify = TRUE)
+      x %<>%
+        str_extract_all(
+          "\\s(PARAMETER(|_VECTOR|_MATRIX|_ARRAY))[(]\\w+[)]",
+          simplify = TRUE
+        )
     } else if (scalar) {
       x %<>% str_extract_all("\\s(PARAMETER)[(]\\w+[)]", simplify = TRUE)
     } else {
-      x %<>% str_extract_all("\\s(PARAMETER(_VECTOR|_MATRIX|_ARRAY))[(]\\w+[)]", simplify = TRUE)
+      x %<>%
+        str_extract_all(
+          "\\s(PARAMETER(_VECTOR|_MATRIX|_ARRAY))[(]\\w+[)]",
+          simplify = TRUE
+        )
     }
-  } else { # ignore REPORT parameters as easily generate using predict
+  } else {
+    # ignore REPORT parameters as easily generate using predict
     x %<>% str_extract_all("\\s(ADREPORT)[(]\\w+[)]", simplify = TRUE)
   }
 

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -2,6 +2,12 @@ test_that("map", {
   expect_identical(map(list()), list())
   expect_identical(map(list(x = c(1, 2))), list())
   expect_identical(map(list(x = c(1, 2, NA))), list(x = factor(c(1, 2, NA))))
-  expect_identical(map(list(y = 1:4, x = c(1, 2, NA))), list(x = factor(c(1, 2, NA))))
-  expect_identical(map(list(y = 1:4, x = matrix(c(1, 2, NA, 4), nrow = 2))), list(x = factor(c(1, 2, NA, 4))))
+  expect_identical(
+    map(list(y = 1:4, x = c(1, 2, NA))),
+    list(x = factor(c(1, 2, NA)))
+  )
+  expect_identical(
+    map(list(y = 1:4, x = matrix(c(1, 2, NA, 4), nrow = 2))),
+    list(x = factor(c(1, 2, NA, 4)))
+  )
 })

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -60,8 +60,13 @@ test_that("analyse", {
   expect_identical(
     pars(mb_code(template), "primary"),
     c(
-      "bAdultsInitial", "bDisturbance", "bHunterDays", "bPDO", "bSurvival",
-      "bYearlingsInitial", "log_sMales"
+      "bAdultsInitial",
+      "bDisturbance",
+      "bHunterDays",
+      "bPDO",
+      "bSurvival",
+      "bYearlingsInitial",
+      "log_sMales"
     )
   )
 
@@ -73,8 +78,14 @@ test_that("analyse", {
   expect_identical(
     pars(mb_code(template), "all"),
     c(
-      "bAdultsInitial", "bDisturbance", "bHunterDays", "bPDO", "bSurvival",
-      "bYearlingsInitial", "log_sMales", "sMales"
+      "bAdultsInitial",
+      "bDisturbance",
+      "bHunterDays",
+      "bPDO",
+      "bSurvival",
+      "bYearlingsInitial",
+      "log_sMales",
+      "sMales"
     )
   )
 
@@ -120,14 +131,33 @@ r2 <- 1 - var(Males - eMales) / var(Males)
   model <- model(
     code = template,
     gen_inits = gen_inits,
-    select_data = list(Males = 1, "Disturbance*" = 1, Year = factor(1), PDO = 1, "HunterDays*" = 1),
+    select_data = list(
+      Males = 1,
+      "Disturbance*" = 1,
+      Year = factor(1),
+      PDO = 1,
+      "HunterDays*" = 1
+    ),
     modify_data = modify_data,
-    new_expr = new_expr, drops = list("bDisturbance", "bPDO", "bHunterDays")
+    new_expr = new_expr,
+    drops = list("bDisturbance", "bPDO", "bHunterDays")
   )
 
   models <- make_all_models(model)
 
   expect_identical(models[[1]], model)
 
-  expect_identical(names(models), c("full", "base+bHunterDays+bPDO", "base+bDisturbance+bPDO", "base+bDisturbance+bHunterDays", "base+bPDO", "base+bHunterDays", "base+bDisturbance", "base"))
+  expect_identical(
+    names(models),
+    c(
+      "full",
+      "base+bHunterDays+bPDO",
+      "base+bDisturbance+bPDO",
+      "base+bDisturbance+bHunterDays",
+      "base+bPDO",
+      "base+bHunterDays",
+      "base+bDisturbance",
+      "base"
+    )
+  )
 })

--- a/tests/testthat/test-zzzanalyse.R
+++ b/tests/testthat/test-zzzanalyse.R
@@ -40,15 +40,28 @@ for (i in 1:length(Pairs)) {
   log(prediction[i]) <- alpha + beta1 * Year[i] + beta2 * Year[i]^2 + beta3 * Year[i]^3 + bAnnual[Annual[i]]
 }"
 
-  gen_inits <- function(data) list(alpha = 4, beta1 = 1, beta2 = 0, beta3 = 0, log_sAnnual = 0, bAnnual = rep(0, data$nAnnual))
+  gen_inits <- function(data) {
+    list(
+      alpha = 4,
+      beta1 = 1,
+      beta2 = 0,
+      beta3 = 0,
+      log_sAnnual = 0,
+      bAnnual = rep(0, data$nAnnual)
+    )
+  }
 
   data <- bauw::peregrine
   data$Annual <- factor(data$Year)
 
-
   model <- model(
-    code = tmb_template, gen_inits = gen_inits,
-    select_data = list("Pairs" = integer(), "Year*" = integer(), Annual = factor()),
+    code = tmb_template,
+    gen_inits = gen_inits,
+    select_data = list(
+      "Pairs" = integer(),
+      "Year*" = integer(),
+      Annual = factor()
+    ),
     random_effects = list(bAnnual = "Annual"),
     new_expr = new_expr
   )
@@ -57,14 +70,35 @@ for (i in 1:length(Pairs)) {
 
   analysis <- analyse(model, data = data, glance = FALSE, beep = FALSE)
 
-  expect_identical(terms(analysis, "fixed", include_constant = FALSE), as_term(sort(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual"))))
+  expect_identical(
+    terms(analysis, "fixed", include_constant = FALSE),
+    as_term(sort(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual")))
+  )
 
-  expect_identical(pars(analysis, "fixed"), sort(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual"))
+  )
   expect_identical(pars(analysis, "random"), "bAnnual")
 
   # not including derived parameters....
-  expect_identical(pars(analysis), sort(c("alpha", "bAnnual", "beta1", "beta2", "beta3", "ePairs", "log_sAnnual", "sAnnual")))
-  expect_identical(pars(analysis, "primary"), sort(c("alpha", "bAnnual", "beta1", "beta2", "beta3", "log_sAnnual")))
+  expect_identical(
+    pars(analysis),
+    sort(c(
+      "alpha",
+      "bAnnual",
+      "beta1",
+      "beta2",
+      "beta3",
+      "ePairs",
+      "log_sAnnual",
+      "sAnnual"
+    ))
+  )
+  expect_identical(
+    pars(analysis, "primary"),
+    sort(c("alpha", "bAnnual", "beta1", "beta2", "beta3", "log_sAnnual"))
+  )
   expect_error(pars(analysis, "some"))
 
   expect_identical(nterms(analysis, "all"), 86L)
@@ -86,20 +120,33 @@ for (i in 1:length(Pairs)) {
 
   expect_is(coef, "tbl")
   expect_is(coef, "mb_analysis_coef")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, sort(as_term(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual"))))
+  expect_identical(
+    coef$term,
+    sort(as_term(c("alpha", "beta1", "beta2", "beta3", "log_sAnnual")))
+  )
 
   profile <- coef_profile(analysis, beep = FALSE)
 
-  expect_identical(colnames(profile), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(profile),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
   expect_identical(
     profile[c("term", "estimate")],
     coef[c("term", "estimate")]
   )
 
-  expect_equal(coef$lower[coef$term == "log_sAnnual"], -2.838932, tolerance = 0.0000001)
+  expect_equal(
+    coef$lower[coef$term == "log_sAnnual"],
+    -2.838932,
+    tolerance = 0.0000001
+  )
   expect_equal(profile$lower[profile$term == "log_sAnnual"], -3.01573026)
 
   tidy <- tidy(analysis)
@@ -108,10 +155,20 @@ for (i in 1:length(Pairs)) {
   year <- predict(analysis, new_data = "Year")
 
   expect_is(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Year", "Pairs", "R.Pairs", "Eyasses", "Annual",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Year",
+      "Pairs",
+      "R.Pairs",
+      "Eyasses",
+      "Annual",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(is.na(year$lower)))
 
   expect_equal(unlist(estimates(analysis)), coef$estimate, check.names = FALSE)


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)